### PR TITLE
Update Kotlin to 1.8.10 and Compose to 2023.01.00

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -10,7 +10,7 @@ java {
 
 dependencies {
     implementation("com.android.tools.build:gradle:7.3.1")
-    implementation("org.jetbrains.kotlin:kotlin-gradle-plugin:1.7.20")
+    implementation("org.jetbrains.kotlin:kotlin-gradle-plugin:1.8.10")
 
     // fix the issue with Hilt down the line: https://github.com/google/dagger/issues/3068
     implementation("com.squareup:javapoet:1.13.0")

--- a/buildSrc/src/main/kotlin/Libs.kt
+++ b/buildSrc/src/main/kotlin/Libs.kt
@@ -3,12 +3,13 @@ object Libs {
     object AndroidX {
 
         object Activity {
-            const val Compose = "androidx.activity:activity-compose:1.6.1"
+            const val Compose = "androidx.activity:activity-compose:1.7.0-beta02"
         }
 
         object Compose {
-            const val CompilerVersion = "1.3.2"
-            const val Bom = "androidx.compose:compose-bom:2022.12.00"
+            // https://androidx.dev/storage/compose-compiler/repository/
+            const val CompilerVersion = "1.4.1-dev-k1.8.10-c312d77f4cb"
+            const val Bom = "androidx.compose:compose-bom:2023.01.00"
             const val Animation = "androidx.compose.animation:animation"
             const val Material = "androidx.compose.material:material"
             const val MaterialIconsExtended = "androidx.compose.material:material-icons-extended"
@@ -22,11 +23,12 @@ object Libs {
         }
 
         object Lifecycle {
-            private const val Version = "2.5.1"
+            private const val Version = "2.6.0-rc01"
 
             object ViewModel {
                 const val Api = "androidx.lifecycle:lifecycle-viewmodel:$Version"
                 const val Compose = "androidx.lifecycle:lifecycle-viewmodel-compose:$Version"
+                const val ComposeRuntime = "androidx.lifecycle:lifecycle-runtime-compose:$Version"
             }
         }
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -12,6 +12,7 @@ dependencyResolutionManagement {
     repositories {
         google()
         mavenCentral()
+        maven("https://androidx.dev/storage/compose-compiler/repository/")
     }
 }
 


### PR DESCRIPTION
Does what it says in the title 😄 
Required some override changes in `BaseNavHostEntry`
Potentially related to https://github.com/olshevski/compose-navigation-reimagined/issues/16

This was originally motivated by a need to use `collectAsStateWithLifecycle` in the state based navigation I'm experimenting with at https://github.com/hbmartin/compose-navigation-reimagined/commit/52e01eb20c005eaada38201148203f4f2cdedb05